### PR TITLE
Remove permission-issues: write from org_inventory.yml

### DIFF
--- a/.github/workflows/org_inventory.yml
+++ b/.github/workflows/org_inventory.yml
@@ -26,7 +26,7 @@ jobs:
           owner: jai-nexus
           permission-contents: read
           # enable only if you plan to write an issue comment (step below)
-          permission-issues: write
+
           # (no 'permissions:' JSON; the action wants per-permission inputs)  # <-- important
 
       - name: Build CSV


### PR DESCRIPTION
This PR removes the request for the issues permission in org_inventory.yml, so the GitHub App only requests read access and avoids permission errors.